### PR TITLE
Wakatime api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a Joplin integration for [WakaTime](https://wakatime.com).
 
 ## Usage
 
-Enter your WakaTime API key in the Joplin settings page for this plugin and restart the Joplin application. As you start typing in a note for Joplin, you will see your stats broken down by notebook in the WakaTime dashboard.
+Enter your WakaTime API key (without "waka_") in the Joplin settings page for this plugin and restart the Joplin application. As you start typing in a note for Joplin, you will see your stats broken down by notebook in the WakaTime dashboard.
 
 ## Supporting the Author
 


### PR DESCRIPTION
I added information so the user knows that the API key needs to be without the "waka_" prefix. I'm not that smart to actually solve the problem, but I think that with this information in the documentation it helps some people